### PR TITLE
Delete a duplicated argument on setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setuptools.setup(
         "Intended Audience :: Education",
         "Intended Audience :: Developers",
         "Natural Language :: English",
-        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
The classifier "Operating System :: OS Independent" is duplicated. I don't think there is a problem deleting it.