### PR TITLE
Don't support more module tests on init_errors.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Bug fixes
   - Internal operation fixes
 - Documentation restructuring
+  - Some contents were moved
+- The `aleat3.output.init_errors` will no longer support module tests, according to PR [\#28](http://github.com/diddileija/aleat3/pull/28)
 
 ### What's new in aleat3 0.2.9
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -240,7 +240,6 @@ Only this files are available for testing:
 
 - aleat3/constructor.py
 - aleat3/output/colored.py
-- aleat3/output/init_errors.py
 
 (Other files are private or `__init__` scripts).
 

--- a/aleat3/output/init_errors.py
+++ b/aleat3/output/init_errors.py
@@ -8,31 +8,3 @@ def KI_bug():
 
 def modal_bug(arg):
     return f"__init__() Invalid Syntax (Unexpected 'mode' given: {arg} when a list was expected)"
-
-######################################################################################################################################################
-def module_test(main_level=False):
-    tmp = [f"__init__() Invalid Syntax (Unexpected parameter given: mode)",
-           f"Program Interrupted by User...",
-           f"__init__() Invalid Syntax (Unexpected parameter given: extras)"]
-    if main_level:
-        from colored import output_red, output_green, output_magenta
-    else:
-        from aleat3.output.colored import output_red, output_green, output_magenta
-    output_magenta("----Module test: init_errors.py----")
-    print("Testing functions...\n")
-    if parameter_bug() == tmp[2]:
-        output_green("-parameter_bug OK")
-        if KI_bug() == tmp[1]:
-            output_green("-ki_bug OK")
-            if modal_bug() == tmp[0]:
-                output_green("-modal_bug OK")
-                output_green("The module is OK.")
-    else:
-        output_red("ERROR: Something failed at test.")
-    output_magenta("----Test finished----")
-    i = input("Done")
-
-if __name__ == '__main__':
-    from colored import output_yellow
-    output_yellow("NOTE: When using this file as __main__ level, you are executing the module test. This operation may take some minutes.")
-    module_test(True)


### PR DESCRIPTION
Since the `aleat3.output.init_errors` functions will format specific error messages, the module tests will surely fail. That way, it won't be ever needed.