### PR TITLE
Add Colorama to the `install_requires` argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setuptools.setup(
         "Documentation": "http://github.com/diddileija/aleat3/blob/main/README.md", # go to README
         "Tracker": "http://github.com/diddileija/aleat3/issues" # GitHub issues page
     },
-    install_requires = ["colorama"] # it will be needed
+    install_requires = ["colorama"] # it will be needed on "aleat3.output.applications"
 )

--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,5 @@ setuptools.setup(
         "Documentation": "http://github.com/diddileija/aleat3/blob/main/README.md", # go to README
         "Tracker": "http://github.com/diddileija/aleat3/issues" # GitHub issues page
     },
+    install_requires = ["colorama"] # it will be needed
 )


### PR DESCRIPTION
The `colorama` package is used on `aleat3.output.colored`. It is used minimally, but it will be needed on some features, such as module tests, `aleat3.applications` files, etc.

I think including it on `setup.py` on the `install_requires` could help.